### PR TITLE
Minor fixes

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -4,11 +4,8 @@ use anyhow::Result;
 use itertools::Itertools;
 use std::ops::Add;
 
-/// @todo #1 Harder unit tests.
-/// We have to make our tests as hard as possible.
-///
 /// Creating a new instance of RJini from a XPATH as string.
-impl RJini {
+impl From<&str> for RJini {
     /// It takes a string and returns a RJini object.
     ///
     /// For example:
@@ -25,18 +22,22 @@ impl RJini {
     /// Returns:
     ///
     /// A struct with a body field.
-    pub fn from(xpath: &str) -> Self {
+    fn from(xpath: &str) -> Self {
         RJini {
             xpath: xpath.to_string(),
         }
     }
+}
 
+/// @todo #1 Harder unit tests.
+/// We have to make our tests as hard as possible.
+impl RJini {
     /// It adds a node to the body of the XPATH.
     ///
     /// For example:
     /// ```
     /// use rjini::RJini;
-    /// let j = RJini::from(&"parent/")
+    /// let j = RJini::from("parent/")
     ///     .add_node("child").unwrap()
     ///     .add_node("game").unwrap();
     /// assert!(j.xpath.contains("child/game/"))

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -50,10 +50,10 @@ impl RJini {
     ///
     /// A new RJini object with the new body.
     pub fn add_node(&self, node: &str) -> Result<RJini> {
-        if node.contains(" ") {
+        if node.contains(' ') {
             return Err(anyhow!(format!("#add_node: The \"{node}\" contain spaces")));
         }
-        let b = self.xpath.clone() + &node + "/";
+        let b = self.xpath.clone() + node + "/";
         Ok(RJini { xpath: b })
     }
 
@@ -110,16 +110,15 @@ impl RJini {
     pub fn replace_node(&self, origin: &str, new: &str) -> RJini {
         let x = self
             .xpath
-            .split("/")
+            .split('/')
             .map(|node| {
-                return if String::from(node).eq(origin) {
+                if String::from(node).eq(origin) {
                     new
                 } else {
                     node
-                };
+                }
             })
-            .join("/")
-            .to_string();
+            .join("/");
         RJini { xpath: x }
     }
 }


### PR DESCRIPTION
Various fixes from `cargo clippy --fix` and explicit implementation of `From<&str>` trait. The last required me to do this change:

~~~diff
- /// let j = RJini::from(&"parent/")
+ /// let j = RJini::from("parent/")
~~~

Because previous version panics with explicit implementation of `From<&str>`. I don't know if it is necessary change, but it seems that it doesn't break anything expect for case above, so why not?